### PR TITLE
Use `ProjectDependency.path` instead of `ProjectDependency.dependencyProject.path` on Gradle 8.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-.gradle
-build
-out
-.idea
+.gradle/
+.kotlin/
+build/
+out/
+.idea/
 *.iml
 *~
 *.hprof

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,6 +1,6 @@
 // Copyright (c) 2024. Tony Robalik.
 // SPDX-License-Identifier: Apache-2.0
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   id("java-gradle-plugin")
@@ -13,9 +13,9 @@ java {
   }
 }
 
-tasks.withType<KotlinCompile>().configureEach {
-  kotlinOptions {
-    jvmTarget = libs.versions.java.get()
+kotlin {
+  compilerOptions {
+    jvmTarget = libs.versions.java.map(JvmTarget::fromTarget).get()
     freeCompilerArgs = listOf("-Xinline-classes", "-opt-in=kotlin.RequiresOptIn", "-Xsam-conversions=class")
   }
 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -7,6 +7,13 @@ pluginManagement {
     gradlePluginPortal()
     mavenCentral()
   }
+  plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+  }
+}
+
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 dependencyResolutionManagement {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-rc-3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,12 +31,13 @@ pluginManagement {
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.gradle.enterprise") version "3.15.1"
     id("com.gradle.plugin-publish") version "1.1.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
   }
 }
 
 plugins {
   id("com.gradle.enterprise")
-  id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
+  id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 // Yes, this is also in pluginManagement above. This is required for normal dependencies.

--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -17,9 +17,9 @@ abstract class AbstractFunctionalSpec extends Specification {
   protected static final GRADLE_8_4 = GradleVersion.version('8.4')
   protected static final GRADLE_8_9 = GradleVersion.version('8.9')
   protected static final GRADLE_8_10 = GradleVersion.version('8.10.2')
-  protected static final GRADLE_8_11 = GradleVersion.version('8.11-rc-1')
+  protected static final GRADLE_8_11 = GradleVersion.version('8.11-rc-3')
 
-  protected static final GRADLE_LATEST = GRADLE_8_10
+  protected static final GRADLE_LATEST = GRADLE_8_11
 
   // For faster CI times, we only test min + max. Testing all would be preferable, but we don't have till the heat death
   // of the universe.

--- a/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
@@ -12,6 +12,7 @@ internal object GradleVersions {
   private val gradle83: GradleVersion = GradleVersion.version("8.3")
   private val gradle85: GradleVersion = GradleVersion.version("8.5")
   private val gradle88: GradleVersion = GradleVersion.version("8.8")
+  private val gradle811: GradleVersion = GradleVersion.version("8.11")
 
   /** Minimum supported version of Gradle. */
   @JvmField val minGradleVersion: GradleVersion = gradle74
@@ -29,4 +30,9 @@ internal object GradleVersions {
    * lifecycle callbacks.
    */
   val isAtLeastGradle88: Boolean = current >= gradle88
+
+  /**
+   * Using [GradleVersion.baseVersion] to make sure it works with `8.11-rc-N` versions too.
+   */
+  val isAtLeastGradle811: Boolean = current.baseVersion >= gradle811
 }

--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -200,7 +200,11 @@ internal fun Dependency.toCoordinates(): Coordinates? {
  */
 internal fun Dependency.toIdentifier(): Pair<ModuleInfo, GradleVariantIdentification>? = when (this) {
   is ProjectDependency -> {
-    val identifier = dependencyProject.path
+    val identifier =
+      if (GradleVersions.isAtLeastGradle811)
+        this.path
+      else
+        @Suppress("DEPRECATION") dependencyProject.path
     Pair(ModuleInfo(identifier.intern()), targetGradleVariantIdentification())
   }
 

--- a/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitSupportExtension.kt
+++ b/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitSupportExtension.kt
@@ -3,6 +3,7 @@
 package com.autonomousapps
 
 import com.autonomousapps.internal.capitalizeSafely
+import com.autonomousapps.internal.pathCompat
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.ProjectDependency
@@ -208,8 +209,8 @@ public abstract class GradleTestKitSupportExtension(private val project: Project
     return configurations.findByName(classpath)?.allDependencies
       ?.filterIsInstance<ProjectDependency>()
       // filter out self-dependency
-      ?.filterNot { it.path == project.path }
-      ?.map { "${it.path}:$taskName" }
+      ?.filterNot { it.pathCompat == project.path }
+      ?.map { "${it.pathCompat}:$taskName" }
   }
 
   /**

--- a/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitSupportExtension.kt
+++ b/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitSupportExtension.kt
@@ -208,8 +208,8 @@ public abstract class GradleTestKitSupportExtension(private val project: Project
     return configurations.findByName(classpath)?.allDependencies
       ?.filterIsInstance<ProjectDependency>()
       // filter out self-dependency
-      ?.filterNot { it.dependencyProject == project }
-      ?.map { "${it.dependencyProject.path}:$taskName" }
+      ?.filterNot { it.path == project.path }
+      ?.map { "${it.path}:$taskName" }
   }
 
   /**

--- a/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/internal/utils.kt
+++ b/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/internal/utils.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.internal
 
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.util.GradleVersion
 import java.util.Locale
 
 internal fun String.capitalizeSafely(locale: Locale = Locale.ROOT): String {
@@ -21,3 +23,14 @@ internal fun String.capitalizeSafely(locale: Locale = Locale.ROOT): String {
   }
   return this
 }
+
+internal val isAtLeastGradle811: Boolean
+  get() = GradleVersion.current().baseVersion >= GradleVersion.version("8.11")
+
+internal val ProjectDependency.pathCompat: String
+  get() =
+    if (isAtLeastGradle811) {
+      this.path
+    } else {
+      @Suppress("DEPRECATION") this.dependencyProject.path
+    }

--- a/testkit/settings.gradle.kts
+++ b/testkit/settings.gradle.kts
@@ -28,11 +28,13 @@ pluginManagement {
     id("com.gradle.enterprise") version "3.15.1"
     id("com.gradle.plugin-publish") version "1.1.0"
     id("org.jetbrains.dokka") version "1.9.20"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
   }
 }
 
 plugins {
   id("com.gradle.enterprise")
+  id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Fixes https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1305

https://github.com/gradle/gradle/blob/2cfa6473bce73ae81838f8e8bd83d74ad7dd6e5b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ProjectDependency.java#L39

Recommended to look at individual commits for motivation of changes.